### PR TITLE
Add a COVERAGE_EXCLUDE_MODULES setting

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,7 +28,11 @@ the test runner will evaluate all modules in the app *zoo* and add them to the c
 
     COVERAGE_MODULES = ('zoo.baer', 'zoo.lion')
 
-to your settings file. In this example *zoo* should be replaced with your application name and *baer/lion* with your module included in the reported.
+to your settings file. In this example *zoo* should be replaced with your application name and *baer/lion* with your module included in the reported.  Modules can be ignored with
+
+    COVERAGE_EXCLUDE_MODULES = ('zoo.tests',)
+
+This will exclude *zoo.tests* and all its submodules from the coverage statistics.
 
 You can also specify a set of apps to test. This option performs in a similar manner to specifying specific apps on the command line, but here you can specify a default set of apps to test in the settings file. To specify a set of apps, add the line
 

--- a/django_test_coverage/runner.py
+++ b/django_test_coverage/runner.py
@@ -68,6 +68,16 @@ def run_tests(test_labels, verbosity=1, interactive=True, failfast=False, extra_
                 modules.extend(_package_modules(*pkg))
         elif hasattr(settings, 'COVERAGE_MODULES'):
             modules = [__import__(module, {}, {}, ['']) for module in settings.COVERAGE_MODULES]
+
+        if hasattr(settings, 'COVERAGE_EXCLUDE_MODULES'):
+            for exclude_module_name in settings.COVERAGE_EXCLUDE_MODULES:
+                # Test designed to avoid accidentally removing a module whose
+                # name is prefixed by an excluded module name, but still remove
+                # submodules
+                modules = [module for module in modules
+                    if not module.__name__ == exclude_module_name and
+                    not module.__name__.startswith(exclude_module_name + '.')]
+
         coverage.report(modules, show_missing=1)
 
     return retval


### PR DESCRIPTION
This lists the names of modules and submodules to be excluded from the printed coverage statistics.
